### PR TITLE
Fix import on Python 3

### DIFF
--- a/rblwatch/__init__.py
+++ b/rblwatch/__init__.py
@@ -1,1 +1,1 @@
-from rblwatch import RBLSearch
+from .rblwatch import RBLSearch


### PR DESCRIPTION
Python 3 removed implicit relative imports, which causes this import to fail, since it will try to import from the `rblwatch` package rather than the `rblwatch.py` file.
Python 2 supports explicit relative imports, so this shouldn't break anything.
